### PR TITLE
controls: fix visual slider clamping behaviour

### DIFF
--- a/controls.go
+++ b/controls.go
@@ -274,6 +274,7 @@ func (ctx *Context) SliderEx(value *float32, low, high, step float32, format str
 	}
 	// clamp and store value, update res
 	*value = clampF(v, low, high)
+	v = *value
 	if last != v {
 		res |= ResChange
 	}


### PR DESCRIPTION
Fixes this visual slider clamping behaviour:

https://github.com/user-attachments/assets/7f84f693-e41b-4db8-8dbf-b7f402b7dfaf

was easy to miss in the original implementation:

https://github.com/rxi/microui/blob/0850aba860959c3e75fb3e97120ca92957f9d057/src/microui.c#L875-L877